### PR TITLE
bump version of requirejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "requirejs-common-wrap-middleware": "0.1.2",
-    "requirejs": "2.1.5",
+    "requirejs": "2.1.20",
     "uglify-js": "2.4.13"
   }
 }


### PR DESCRIPTION
Была проблема: browserify создает анонимные дефайны, а requirejs@2.1.5 не может их оптимизировать. В 2.1.20 всё нормально.
