### PR TITLE
Use relative file paths for cache keys

### DIFF
--- a/lib/appMaker.js
+++ b/lib/appMaker.js
@@ -199,6 +199,7 @@ exports.jadeAmdCompile = function(config) {
 
 /** Optimize js in parallel */
 exports.jsOptimizeParallel = function(params, callback) {
+
 	params = params || {};
 	_(params).defaults({
 		showStdout: false,
@@ -286,7 +287,12 @@ exports.jsOptimizeParallel = function(params, callback) {
 		var hashsum = fileHashsum(file),
 			outFile = file + '_tmp_',
 			cachedFile = cache ? path.join(params.cacheDir, hashsum) : null;
-		if (cache && file in cache && hashsum == cache[file] && fs.existsSync(cachedFile)) {
+
+		var fileRelativePath = cache ? path.relative(params.cacheDir, file) : file;
+		if (
+			cache && fileRelativePath in cache && hashsum == cache[fileRelativePath] &&
+			fs.existsSync(cachedFile)
+		) {
 			fs.writeFileSync(file, fs.readFileSync(cachedFile));
 			stat.fromCache++;
 			printContent('skip optimization for ' + file + ' due cache');
@@ -306,7 +312,7 @@ exports.jsOptimizeParallel = function(params, callback) {
 			if (stderr && params.showStderr) printContent(stderr);
 			if (!err) {
 				if (cache) {
-					cache[file] = hashsum;
+					cache[fileRelativePath] = hashsum;
 					fs.writeFileSync(cachedFile, fs.readFileSync(outFile));
 				}
 				fs.renameSync(outFile, file);


### PR DESCRIPTION
Generate cache item keys as path related to `cacheDir` path. It will allow to change project path without cache invalidation.
